### PR TITLE
Adjust Safari safe-area background color

### DIFF
--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -7,6 +7,7 @@ html {
 body {
   margin: 0;
   padding: 0;
+  padding-bottom: env(safe-area-inset-bottom);
   width: 100%;
   min-height: 100vh;
   display: flow-root;
@@ -19,6 +20,17 @@ body {
   @media #{$medium} {
     background-color: $body-color;
   }
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: env(safe-area-inset-bottom);
+  background-color: $body-color;
+  pointer-events: none;
 }
 
 iframe {


### PR DESCRIPTION
### Motivation
- On iOS Safari the bottom safe-area area rendered as white which contrasts with the site gray background and looks abrupt.
- Prevent page content from overlapping the iPhone home indicator area by reserving the safe-area inset.
- Ensure the bottom safe-area visually matches the desktop/mobile site background color for a seamless edge.

### Description
- Update `_sass/_page.scss` to add `padding-bottom: env(safe-area-inset-bottom)` on the `body` element.
- Render a fixed strip using `body::after` with `height: env(safe-area-inset-bottom)` and `background-color: $body-color` so the safe-area displays gray.
- The pseudo-element uses `position: fixed` and `pointer-events: none` to avoid affecting layout or interactions.

### Testing
- No automated tests were executed for this change.
- Visual verification on an iOS device or simulator is recommended to confirm the safe-area appears as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a991969dc833284c3fd407ed13c4a)